### PR TITLE
fix uncaught error after timeout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,12 +233,12 @@ const downloadMetadata = (pkgName: string, options?: LatestVersionOptions): Prom
             }
         });
         const abort = (error: Error | string): void => {
-            request.removeAllListeners();
             request.destroy();
             reject(error);
         };
         request.once('timeout', () => { abort(`Request timed out: ${pkgUrl}`); });
         request.once('error', (err: Error) => { abort(err); });
+        request.on('close', () => { request.removeAllListeners(); });
     });
 };
 


### PR DESCRIPTION
reproduction step:
```ts
async function getLatestVersion(pkgNames: string[]) {
  return latestVersion(pkgNames, {
    requestOptions: {
      timeout: 1,
    },
  })
    .then((pkgs) => pkgs.map((pkg) => pkg.latest))
    .catch(() => []);
}
```

print error logs:
```js
    const abort = (error) => {
      // request.removeAllListeners();
      request.destroy();
      reject(error);
    };
    request.once("timeout", () => {
      console.log("timeout");
      abort(`Request timed out: ${pkgUrl}`);
    });
    request.once("error", (err) => {
      console.log("error", err);
      abort(err);
    });
    request.on("close", () => {
      console.log("close");
      request.removeAllListeners();
    });
```

and you'll see something like: 
![image](https://github.com/user-attachments/assets/16944238-356c-4e4c-abae-374bfb521247)

because timeout event removes lisenters too early and `request.destroy()` may cause new errors
